### PR TITLE
Split feeds (Lap / Shallow / Dive) + landing page

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish EKAC lanes calendar
 
 on:
   schedule:
-    - cron: "10 9 * * *"   # daily publish
+    - cron: "0 8 * * *"   # daily publish 4am ET
   workflow_dispatch:
     inputs:
       debug:

--- a/README.md
+++ b/README.md
@@ -1,27 +1,42 @@
 # bhs-pool-calendar
 
-Scrapes the latest Brookline High School / Evelyn Kirrane Aquatics Center **Pool Schedule** PDF and publishes an
-iCal feed showing **lap-lane availability** (“Lap lanes: N or N–M open”) via GitHub Actions + Pages. Zero servers.
+Generates iCal feeds for the Evelyn Kirrane Aquatics Center (Brookline High School) pool schedule by parsing the
+weekly PDF and publishing calendars via GitHub Actions + Pages.
 
-**Calendar URL (after enabling GitHub Pages):**
-https://samuelduchesne.github.io/bhs-pool-calendar/ekac.ics
+## About & Disclaimer
+
+> **Unofficial project.** This repository is maintained by the community and is not affiliated with the Town of
+> Brookline. The feeds are generated automatically by scraping the public PDF. **No guarantees**: parsing can be wrong,
+> stale, or incomplete. **Always confirm** with the facility’s official schedule:
+> https://www.brooklinerec.com/150/Aquatics-Center  
+> This is just a fun project using ChatGPT 5.
+
+---
+
+## Feeds
+
+Landing page (choose your calendar):  
+https://samuelduchesne.github.io/bhs-pool-calendar/
+
+Direct feeds:
+- **Lap lanes:** https://samuelduchesne.github.io/bhs-pool-calendar/ekac-lap.ics
+- **Shallow pool:** https://samuelduchesne.github.io/bhs-pool-calendar/ekac-shallow.ics
+- **Dive well:** https://samuelduchesne.github.io/bhs-pool-calendar/ekac-dive.ics
+- **All-in-one:** https://samuelduchesne.github.io/bhs-pool-calendar/ekac.ics
+
+> Subscribe in Apple/Google Calendar by adding the `.ics` URL.
 
 ## How it works
-- Discovers the newest **Pool Schedule** PDF from the Aquatics page; falls back to a stable DocumentCenter ID.
-- Parses Monday–Sunday columns and converts each time block with lane counts into a calendar event.
-- Exports events in **UTC** so calendar apps render correctly in local time (America/New_York).
-- Publishes daily at ~05:10 ET and on manual runs via GitHub Actions. Output is served by **GitHub Pages**.
 
-## Quick deploy (phone-friendly)
-1. Create repo `bhs-pool-calendar` (Public).
-2. Add `.github/workflows/publish.yml` (see repo) and commit to `main`.
-3. Repo → **Settings → Pages** → Source: **GitHub Actions**.
-4. **Actions** tab → run “Publish EKAC lanes calendar”.
-5. Subscribe to the Calendar URL above in Apple/Google Calendar.
+- Finds the latest “Pool Schedule” PDF on the Aquatics page (with a stable fallback).
+- Parses weekday columns using page geometry; clusters text into rows to extract time ranges.
+- Builds four iCal feeds (Lap / Shallow / Dive / All) and publishes them to GitHub Pages on a daily cron
+  and on manual runs.
 
-## Local development
+## Development
+
 ```bash
 python -m venv .venv && source .venv/bin/activate
-pip install requests pdfplumber python-dateutil icalendar beautifulsoup4
+pip install -r requirements.txt
 python app/build_calendar.py
-open public/ekac.ics
+open public/index.html

--- a/README.md
+++ b/README.md
@@ -40,3 +40,22 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 python app/build_calendar.py
 open public/index.html
+```
+
+Environment toggles (used by the workflow):
+
+- `DEBUG=1` → publish debug.html / debug.json for troubleshooting
+- `ROW_TOL` (default 3.5) → row clustering tolerance (pixels)
+- `COL_GUTTER_PX` (default 16) → left-bias gutter to prevent Sat/Sun column bleed
+- `COL_LEFT_BIAS_PX` (default 6) → tie-break toward the left column
+
+### Contributing
+
+Issues and PRs are welcome—especially if the PDF layout changes and parsing needs tweaks.
+If you report a parsing problem, please include:
+	•	Date/day and the affected row text from debug.html
+	•	What the expected events should be
+
+### License
+
+MIT. See [LICENSE](LICENSE).

--- a/app/build_calendar.py
+++ b/app/build_calendar.py
@@ -435,7 +435,7 @@ def _write_debug(debug: dict, blocks: list[Block]) -> None:
 
 
 def _write_index() -> None:
-    """Landing page with links to feeds."""
+    """Landing page with an about/disclaimer section and links to feeds."""
     os.makedirs("public", exist_ok=True)
     owner = os.getenv("GITHUB_REPOSITORY_OWNER", "")
     repo = os.getenv("GITHUB_REPOSITORY", "")
@@ -446,33 +446,57 @@ def _write_index() -> None:
 <style>
  body{{font:16px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial;margin:24px;color:#222}}
  .card{{border:1px solid #e7e7e7;border-radius:8px;padding:16px;margin:12px 0}}
+ .notice{{background:#fffbea;border-color:#ffe08a}}
  code{{background:#f5f5f5;padding:2px 4px;border-radius:4px}}
  a{{text-decoration:none}}
  h1{{margin:0 0 12px 0}} h2{{margin:12px 0}} p{{margin:8px 0}}
 </style></head><body>
+
+<div class="card notice">
+  <h2>About this project</h2>
+  <p>
+    Unofficial, community-built calendars generated from the weekly Pool Schedule PDF published by the
+    Town of Brookline Recreation Department. For the official schedule, see
+    <a href="{AQUATICS_URL}">the Aquatics Center page</a>.
+  </p>
+  <p>
+    <b>Disclaimer:</b> No guarantees. Parsing can be wrong or out of date; always confirm with the facility.
+    This is just a fun project using ChatGPT 5!
+  </p>
+  <p>Source code: <a href="https://github.com/{repo}">github.com/{repo}</a></p>
+</div>
+
 <h1>Evelyn Kirrane Aquatics Center — Pool Schedules</h1>
 <p>Subscribe to one or more calendars:</p>
+
 <div class="card">
   <h2>Lap Lanes</h2>
   <p>Shows lane availability (e.g., “Lap lanes: 4–5 open”).</p>
-  <p><a href="ekac-lap.ics"><b>HTTPS</b></a> &nbsp;|&nbsp; <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-lap.ics"><b>webcal://</b></a></p>
+  <p><a href="ekac-lap.ics"><b>HTTPS</b></a> &nbsp;|&nbsp;
+     <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-lap.ics"><b>webcal://</b></a></p>
 </div>
+
 <div class="card">
   <h2>Shallow Pool</h2>
   <p>Shallow pool open/closed times.</p>
-  <p><a href="ekac-shallow.ics"><b>HTTPS</b></a> &nbsp;|&nbsp; <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-shallow.ics"><b>webcal://</b></a></p>
+  <p><a href="ekac-shallow.ics"><b>HTTPS</b></a> &nbsp;|&nbsp;
+     <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-shallow.ics"><b>webcal://</b></a></p>
 </div>
+
 <div class="card">
   <h2>Dive Well</h2>
   <p>Dive well open/closed times.</p>
-  <p><a href="ekac-dive.ics"><b>HTTPS</b></a> &nbsp;|&nbsp; <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-dive.ics"><b>webcal://</b></a></p>
+  <p><a href="ekac-dive.ics"><b>HTTPS</b></a> &nbsp;|&nbsp;
+     <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-dive.ics"><b>webcal://</b></a></p>
 </div>
+
 <div class="card">
   <h2>All-in-one</h2>
   <p>Includes Lap, Shallow, and Dive in one feed.</p>
-  <p><a href="ekac.ics"><b>HTTPS</b></a> &nbsp;|&nbsp; <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac.ics"><b>webcal://</b></a></p>
+  <p><a href="ekac.ics"><b>HTTPS</b></a> &nbsp;|&nbsp;
+     <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac.ics"><b>webcal://</b></a></p>
 </div>
-<p style="margin-top:24px">Source code: <a href="https://github.com/{repo}">GitHub</a></p>
+
 </body></html>"""
     with open("public/index.html", "w", encoding="utf-8") as f:
         f.write(html)

--- a/app/build_calendar.py
+++ b/app/build_calendar.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python3
-"""Build an iCal feed for EKAC lap lanes, with optional debug artifacts.
+"""Build iCal feeds for EKAC Lap, Shallow, and Dive, with optional debug artifacts.
 
-- Discovers the latest Pool Schedule PDF (Aquatics page; falls back to fixed ID).
-- Parses by weekday columns, clustering words into visual rows (robust to token splits).
-- Emits iCal events in UTC and (if DEBUG=1) writes debug.html / debug.json.
+- Finds the latest Pool Schedule PDF (Aquatics page; fallback to fixed ID).
+- Splits page into weekday columns (left-biased boundary to prevent bleed).
+- Clusters words into visual rows; assigns each row to the nearest section header above:
+  ["Lap Lanes", "Shallow Pool", "Dive Well"].
+- Extracts time ranges and, for Lap, the lane counts (to the RIGHT of the time).
+- Writes four feeds:
+    public/ekac-lap.ics
+    public/ekac-shallow.ics
+    public/ekac-dive.ics
+    public/ekac.ics  (combined)
+- Writes public/index.html (landing page). If DEBUG=1, also debug.html / debug.json.
 
 Env:
-  DEBUG=1       -> write debug artifacts to public/
-  ROW_TOL=3.5   -> row-clustering tolerance in pixels (float)
+  DEBUG=1                 -> write debug artifacts
+  ROW_TOL=3.5             -> row clustering tolerance (px)
+  COL_GUTTER_PX=16        -> left-biased gutter (px) near day boundaries
+  COL_LEFT_BIAS_PX=6      -> tie-break toward the left column (px)
 """
 
 from __future__ import annotations
@@ -20,7 +30,7 @@ import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Iterable, List, Tuple
+from typing import Iterable, Literal, Tuple
 
 import pdfplumber
 import requests
@@ -34,17 +44,26 @@ FALLBACK_PDF = "https://www.brooklinerec.com/DocumentCenter/View/4404/Pool-Sched
 DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
 DEBUG = os.environ.get("DEBUG", "0") == "1"
-try:
-    ROW_TOL = float(os.environ.get("ROW_TOL", "3.5"))
-except ValueError:
-    ROW_TOL = 3.5
+
+def _get_float_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+ROW_TOL = _get_float_env("ROW_TOL", 3.5)
+COL_GUTTER_PX = _get_float_env("COL_GUTTER_PX", 16.0)
+COL_LEFT_BIAS_PX = _get_float_env("COL_LEFT_BIAS_PX", 6.0)
+
+Kind = Literal["lap", "shallow", "dive"]
 
 
 @dataclass(frozen=True)
 class Block:
     start: datetime  # UTC
     end: datetime    # UTC
-    lanes_label: str
+    kind: Kind
+    label: str       # "5", "4–5" for lap; "open" for shallow/dive
     source_url: str
     page: int
     day: str
@@ -52,7 +71,6 @@ class Block:
 
 
 def discover_latest_pdf() -> str:
-    """Find the latest Pool Schedule PDF URL with a robust fallback."""
     try:
         resp = requests.get(AQUATICS_URL, timeout=30)
         resp.raise_for_status()
@@ -72,7 +90,6 @@ def discover_latest_pdf() -> str:
 
 
 def month_span_to_dates(header: str, now_utc: datetime) -> Tuple[datetime, datetime] | None:
-    """Parse 'Pool Schedule for August 4-10' -> (start_date, end_date) at midnight UTC."""
     m = re.search(r"Pool Schedule\s*(?:for)?\s+([A-Za-z]+)\s+(\d{1,2})\s*[-–]\s*(\d{1,2})", header)
     if not m:
         return None
@@ -90,16 +107,13 @@ def month_span_to_dates(header: str, now_utc: datetime) -> Tuple[datetime, datet
 
 
 def to_utc_local_eastern(local_date: datetime, hh: int, mm: int) -> datetime:
-    """Convert America/New_York local time to UTC for ICS."""
     from zoneinfo import ZoneInfo
-
     eastern = ZoneInfo("America/New_York")
     local_dt = datetime(local_date.year, local_date.month, local_date.day, hh, mm, tzinfo=eastern)
     return local_dt.astimezone(timezone.utc)
 
 
 def time_token_to_24h(tstr: str) -> tuple[int, int]:
-    """Accept '7a', '7 am', '7:15a', '7:15 pm', etc."""
     s = tstr.strip().lower().replace(" ", "")
     m = re.fullmatch(r"(\d{1,2})(?::(\d{2}))?(a|p|am|pm)", s)
     if not m:
@@ -115,7 +129,6 @@ def time_token_to_24h(tstr: str) -> tuple[int, int]:
 
 
 def _rows_from_words(day_words: list[dict], tol: float = ROW_TOL) -> list[list[dict]]:
-    """Cluster tokens into visual rows by y ('top') with tolerance."""
     if not day_words:
         return []
     ws = sorted(day_words, key=lambda w: (w["top"], w["x0"]))
@@ -136,7 +149,7 @@ def _rows_from_words(day_words: list[dict], tol: float = ROW_TOL) -> list[list[d
 
 
 def group_by_day_columns(words: list[dict]) -> tuple[dict[str, list[dict]], dict]:
-    """Assign tokens to weekday columns with a left-biased boundary to avoid spillover."""
+    """Assign tokens to weekday columns with a left-biased boundary gutter."""
     name_map = {
         "monday": "Monday", "mon": "Monday",
         "tuesday": "Tuesday", "tue": "Tuesday", "tues": "Tuesday",
@@ -146,15 +159,6 @@ def group_by_day_columns(words: list[dict]) -> tuple[dict[str, list[dict]], dict
         "saturday": "Saturday", "sat": "Saturday",
         "sunday": "Sunday", "sun": "Sunday",
     }
-
-    try:
-        gutter_px = float(os.environ.get("COL_GUTTER_PX", "16.0"))  # boundary gutter
-    except ValueError:
-        gutter_px = 16.0
-    try:
-        left_bias_px = float(os.environ.get("COL_LEFT_BIAS_PX", "6.0"))
-    except ValueError:
-        left_bias_px = 6.0
 
     headers: list[tuple[str, float]] = []
     for w in words:
@@ -190,7 +194,6 @@ def group_by_day_columns(words: list[dict]) -> tuple[dict[str, list[dict]], dict
             centers.append((day, (left + right) / 2.0))
         debug["mode"] = "equal-bands"
 
-    # Midpoint boundaries between centers:
     bounds = [(centers[i][1] + centers[i + 1][1]) / 2.0 for i in range(len(centers) - 1)]
     debug["bounds"] = bounds
     debug["centers"] = centers
@@ -198,17 +201,12 @@ def group_by_day_columns(words: list[dict]) -> tuple[dict[str, list[dict]], dict
     columns: dict[str, list[dict]] = {d: [] for d, _ in centers}
     for w in words:
         xmid = (w["x0"] + w["x1"]) / 2.0
-
-        # Nearest center
         dists = [abs(xmid - c[1]) for c in centers]
         j = min(range(len(dists)), key=lambda k: dists[k])
-
-        # If we're within a gutter of the left boundary of this column, shove left.
         if j > 0:
             left_boundary = (centers[j - 1][1] + centers[j][1]) / 2.0
-            if xmid - left_boundary <= gutter_px and (dists[j] - dists[j - 1]) <= left_bias_px:
+            if xmid - left_boundary <= COL_GUTTER_PX and (dists[j] - dists[j - 1]) <= COL_LEFT_BIAS_PX:
                 j -= 1
-
         columns[centers[j][0]].append(w)
 
     for d in columns:
@@ -216,53 +214,88 @@ def group_by_day_columns(words: list[dict]) -> tuple[dict[str, list[dict]], dict
     return columns, debug
 
 
-def extract_blocks_for_day(
-    day_words: list[dict],
-    local_date: datetime,
-) -> Iterable[tuple[datetime, datetime, str, str]]:
-    """Yield (start_utc, end_utc, lanes_label, row_text) scanning only to the RIGHT of the time range.
+SECTION_KEYS = {
+    "lap": ["lap lane", "lap lanes", "lap swim", "lap"],
+    "shallow": ["shallow pool", "shallow"],
+    "dive": ["dive well", "diving well", "dive"],
+}
 
-    Assumes lane counts always follow the time (same row). We purposely ignore any numbers to the left
-    to avoid picking up neighboring-column junk (e.g., Saturday counts showing up in Sunday).
-    """
+
+def _section_markers(words: list[dict]) -> list[tuple[float, Kind]]:
+    """Return [(y_top, kind)] for section headers within a single day column."""
+    markers: list[tuple[float, Kind]] = []
+    for w in words:
+        txt = w["text"].strip().lower()
+        for kind, keys in SECTION_KEYS.items():
+            if any(k in txt for k in keys):
+                markers.append((w["top"], kind))  # y position
+                break
+    markers.sort(key=lambda t: t[0])
+    return markers
+
+
+def _assign_kind(row: list[dict], markers: list[tuple[float, Kind]], default: Kind = "lap") -> Kind:
+    """Assign kind by the nearest marker ABOVE the row; default if none found."""
+    if not markers or not row:
+        return default
+    y = sum(w["top"] for w in row) / len(row)
+    above = [m for m in markers if m[0] <= y + 0.01]
+    if not above:
+        return default
+    return above[-1][1]
+
+
+def extract_blocks_for_day(day_words: list[dict], local_date: datetime) -> Iterable[Block]:
+    """Yield Blocks for the day, categorized by section; counts are right-side only for Lap."""
     time_re = re.compile(
-        r"(?P<s>\d{1,2}(?::\d{2})?\s*(?:a|p|am|pm))\s*[-–]\s*(?P<e>\d{1,2}(?::\d{2})?\s*(?:a|p|am|pm))",
+        r"(?P<s>\d{1,2}(?::\d{2})?\s*(?:a|p|am|pm))\s*[-–]\s*"
+        r"(?P<e>\d{1,2}(?::\d{2})?\s*(?:a|p|am|pm))",
         re.IGNORECASE,
     )
-    # Right-side lane pattern: 5, 4-5, 4–5, with optional "lanes"
     lanes_right_re = re.compile(
         r"(?<!\d)(?P<n1>\d{1,2})(?:\s*[–-]\s*(?P<n2>\d{1,2}))?(?:\s*lanes?)?(?!\d)",
         re.IGNORECASE,
     )
 
+    markers = _section_markers(day_words)
     for row in _rows_from_words(day_words, tol=ROW_TOL):
         row_text = " ".join(w["text"] for w in row)
-        m = time_re.search(row_text)
-        if not m:
+        tm = time_re.search(row_text)
+        if not tm:
             continue
 
-        # only look to the RIGHT of the time range
-        post = row_text[m.end():]
-        m2 = lanes_right_re.search(post)
-        if not m2:
-            # strict: skip if lanes not found to the right
-            continue
-
-        n1 = int(m2.group("n1"))
-        n2 = m2.group("n2")
-        lanes = f"{n1}–{int(n2)}" if n2 else f"{n1}"
-
-        sh, sm = time_token_to_24h(m.group("s"))
-        eh, em = time_token_to_24h(m.group("e"))
+        kind = _assign_kind(row, markers, default="lap")
+        sh, sm = time_token_to_24h(tm.group("s"))
+        eh, em = time_token_to_24h(tm.group("e"))
         st_utc = to_utc_local_eastern(local_date, sh, sm)
         en_utc = to_utc_local_eastern(local_date, eh, em)
         if en_utc <= st_utc:
             en_utc += timedelta(days=1)
 
-        yield st_utc, en_utc, lanes, row_text
+        if kind == "lap":
+            post = row_text[tm.end():]
+            m2 = lanes_right_re.search(post)
+            if not m2:
+                continue  # lap rows must have counts to the right
+            n1 = int(m2.group("n1"))
+            n2 = m2.group("n2")
+            label = f"{n1}–{int(n2)}" if n2 else f"{n1}"
+        else:
+            label = "open"
+
+        yield Block(
+            start=st_utc,
+            end=en_utc,
+            kind=kind,
+            label=label,
+            source_url="",
+            page=0,
+            day="",  # filled by caller
+            row_text=row_text,
+        )
+
 
 def parse_pdf(url: str) -> tuple[list[Block], dict]:
-    """Download and parse the PDF into lap-lane blocks; collect debug info."""
     r = requests.get(url, timeout=60)
     r.raise_for_status()
     now_utc = datetime.now(timezone.utc)
@@ -293,27 +326,29 @@ def parse_pdf(url: str) -> tuple[list[Block], dict]:
 
             for offset, day in enumerate(DAYS):
                 local_date = week_start + timedelta(days=offset)
-                rows = [" ".join(w["text"] for w in row) for row in _rows_from_words(columns.get(day, []))]
-                page_dbg["days"][day] = {"row_count": len(rows), "rows": rows, "matches": []}
+                day_words = columns.get(day, [])
+                rows = [" ".join(w["text"] for w in _rows_from_words(day_words))]
+                page_dbg["days"][day] = {"rows": rows, "matches": []}
 
-                for st_utc, en_utc, label, row_text in extract_blocks_for_day(columns.get(day, []), local_date):
-                    blocks.append(
-                        Block(
-                            start=st_utc,
-                            end=en_utc,
-                            lanes_label=label,
-                            source_url=url,
-                            page=page_index,
-                            day=day,
-                            row_text=row_text,
-                        )
+                for blk in extract_blocks_for_day(day_words, local_date):
+                    blk = Block(
+                        start=blk.start,
+                        end=blk.end,
+                        kind=blk.kind,
+                        label=blk.label,
+                        source_url=url,
+                        page=page_index,
+                        day=day,
+                        row_text=blk.row_text,
                     )
+                    blocks.append(blk)
                     page_dbg["days"][day]["matches"].append(
                         {
-                            "start": st_utc.isoformat(),
-                            "end": en_utc.isoformat(),
-                            "lanes": label,
-                            "row_text": row_text,
+                            "start": blk.start.isoformat(),
+                            "end": blk.end.isoformat(),
+                            "kind": blk.kind,
+                            "label": blk.label,
+                            "row_text": blk.row_text,
                         }
                     )
 
@@ -322,36 +357,45 @@ def parse_pdf(url: str) -> tuple[list[Block], dict]:
     return blocks, debug
 
 
-def make_calendar(blocks: Iterable[Block]) -> Calendar:
-    """Create the iCal, one VEVENT per block."""
+def make_calendar(blocks: list[Block], kind: Kind | None, calname: str) -> Calendar:
+    """If kind is None, include all kinds."""
     cal = Calendar()
-    cal.add("prodid", "-//Brookline EKAC Lanes//bhs-pool-calendar//EN")
+    cal.add("prodid", "-//Brookline EKAC Feeds//bhs-pool-calendar//EN")
     cal.add("version", "2.0")
-    cal.add("x-wr-calname", "Brookline EKAC Lap Lanes")
+    cal.add("x-wr-calname", calname)
     cal.add("x-wr-timezone", "America/New_York")
+
     for b in blocks:
+        if kind and b.kind != kind:
+            continue
         ev = Event()
         ev.add("dtstart", b.start)
         ev.add("dtend", b.end)
-        ev.add("summary", f"Lap lanes: {b.lanes_label.replace('-', '–')} open")
+        if b.kind == "lap":
+            ev.add("summary", f"Lap lanes: {b.label.replace('-', '–')} open")
+        elif b.kind == "shallow":
+            ev.add("summary", "Shallow pool: open")
+        else:
+            ev.add("summary", "Dive well: open")
         ev.add("location", "Evelyn Kirrane Aquatics Center, 60 Tappan St, Brookline, MA 02446")
-        ev.add("description", f"Page {b.page}, {b.day}\nRow: {b.row_text}\nSource: {b.source_url}")
-        uid_raw = f"{b.start.isoformat()}|{b.end.isoformat()}|{b.lanes_label}"
+        ev.add("description", f"{b.day} — {b.row_text}\nSource: {b.source_url} (page {b.page})")
+        uid_raw = f"{b.start.isoformat()}|{b.end.isoformat()}|{b.kind}|{b.label}"
         ev.add("uid", f"ekac-{hashlib.sha1(uid_raw.encode('utf-8')).hexdigest()}@bhs-pool-calendar")
         cal.add_component(ev)
+
     return cal
 
 
 def _write_debug(debug: dict, blocks: list[Block]) -> None:
-    """Write debug.json + debug.html to public/."""
     os.makedirs("public", exist_ok=True)
     with open("public/debug.json", "w", encoding="utf-8") as f:
         json.dump({"debug": debug, "event_count": len(blocks)}, f, indent=2)
 
     lines = []
-    lines.append("<html><head><meta charset='utf-8'><meta name='robots' content='noindex,nofollow'>"
-             "<title>EKAC Debug</title>")
     lines.append(
+        "<html><head><meta charset='utf-8'>"
+        "<meta name='robots' content='noindex,nofollow'>"
+        "<title>EKAC Debug</title>"
         "<style>body{font:14px/1.4 -apple-system,Segoe UI,Roboto,Helvetica,Arial}"
         "pre{white-space:pre-wrap;word-break:break-word}"
         "details{margin:8px 0}summary{font-weight:600}"
@@ -360,6 +404,10 @@ def _write_debug(debug: dict, blocks: list[Block]) -> None:
     )
     lines.append(f"<h2>PDF: <code>{debug.get('pdf')}</code></h2>")
     lines.append(f"<p>Total parsed events: <b>{len(blocks)}</b></p>")
+    kind_counts = {"lap": 0, "shallow": 0, "dive": 0}
+    for b in blocks:
+        kind_counts[b.kind] += 1
+    lines.append(f"<p>By kind: {kind_counts}</p>")
     for page in debug.get("pages", []):
         lines.append(f"<h3>Page {page['page']}</h3>")
         lines.append(f"<p>Header: <code>{page['header']}</code></p>")
@@ -372,18 +420,62 @@ def _write_debug(debug: dict, blocks: list[Block]) -> None:
         lines.append("</pre></details>")
         for day in DAYS:
             d = page["days"].get(day, {})
-            cls = "ok" if d.get("matches") else "bad"
+            matches = d.get("matches", [])
+            cls = "ok" if matches else "bad"
             lines.append(
-                f"<details open><summary class='{cls}'>{day}: "
-                f"{len(d.get('matches', []))} matches | {d.get('row_count', 0)} rows</summary>"
+                f"<details open><summary class='{cls}'>{day}: {len(matches)} matches</summary>"
             )
             lines.append("<pre>Rows:\n" + "\n".join(d.get("rows", [])) + "</pre>")
-            if d.get("matches"):
-                lines.append("<pre>Matches:\n" + json.dumps(d["matches"], indent=2) + "</pre>")
+            if matches:
+                lines.append("<pre>Matches:\n" + json.dumps(matches, indent=2) + "</pre>")
             lines.append("</details>")
     lines.append("</body></html>")
     with open("public/debug.html", "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
+
+
+def _write_index() -> None:
+    """Landing page with links to feeds."""
+    os.makedirs("public", exist_ok=True)
+    owner = os.getenv("GITHUB_REPOSITORY_OWNER", "")
+    repo = os.getenv("GITHUB_REPOSITORY", "")
+    html = f"""<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>EKAC Pool Feeds</title>
+<style>
+ body{{font:16px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial;margin:24px;color:#222}}
+ .card{{border:1px solid #e7e7e7;border-radius:8px;padding:16px;margin:12px 0}}
+ code{{background:#f5f5f5;padding:2px 4px;border-radius:4px}}
+ a{{text-decoration:none}}
+ h1{{margin:0 0 12px 0}} h2{{margin:12px 0}} p{{margin:8px 0}}
+</style></head><body>
+<h1>Evelyn Kirrane Aquatics Center — Pool Schedules</h1>
+<p>Subscribe to one or more calendars:</p>
+<div class="card">
+  <h2>Lap Lanes</h2>
+  <p>Shows lane availability (e.g., “Lap lanes: 4–5 open”).</p>
+  <p><a href="ekac-lap.ics"><b>HTTPS</b></a> &nbsp;|&nbsp; <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-lap.ics"><b>webcal://</b></a></p>
+</div>
+<div class="card">
+  <h2>Shallow Pool</h2>
+  <p>Shallow pool open/closed times.</p>
+  <p><a href="ekac-shallow.ics"><b>HTTPS</b></a> &nbsp;|&nbsp; <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-shallow.ics"><b>webcal://</b></a></p>
+</div>
+<div class="card">
+  <h2>Dive Well</h2>
+  <p>Dive well open/closed times.</p>
+  <p><a href="ekac-dive.ics"><b>HTTPS</b></a> &nbsp;|&nbsp; <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac-dive.ics"><b>webcal://</b></a></p>
+</div>
+<div class="card">
+  <h2>All-in-one</h2>
+  <p>Includes Lap, Shallow, and Dive in one feed.</p>
+  <p><a href="ekac.ics"><b>HTTPS</b></a> &nbsp;|&nbsp; <a href="webcal://{owner}.github.io/bhs-pool-calendar/ekac.ics"><b>webcal://</b></a></p>
+</div>
+<p style="margin-top:24px">Source code: <a href="https://github.com/{repo}">GitHub</a></p>
+</body></html>"""
+    with open("public/index.html", "w", encoding="utf-8") as f:
+        f.write(html)
 
 
 def main() -> int:
@@ -391,14 +483,24 @@ def main() -> int:
     blocks, debug = parse_pdf(pdf_url)
 
     os.makedirs("public", exist_ok=True)
-    cal = make_calendar(blocks)
-    with open("public/ekac.ics", "wb") as f:
-        f.write(cal.to_ical())
+    for kind, fname, title in [
+        ("lap", "ekac-lap.ics", "Brookline EKAC — Lap Lanes"),
+        ("shallow", "ekac-shallow.ics", "Brookline EKAC — Shallow Pool"),
+        ("dive", "ekac-dive.ics", "Brookline EKAC — Dive Well"),
+        (None, "ekac.ics", "Brookline EKAC — All Pools"),
+    ]:
+        cal = make_calendar(blocks, kind if isinstance(kind, str) else None, title)  # type: ignore[arg-type]
+        with open(f"public/{fname}", "wb") as f:
+            f.write(cal.to_ical())
 
+    _write_index()
     if DEBUG:
         _write_debug(debug, blocks)
 
-    print(f"Wrote public/ekac.ics with {len(blocks)} events from {pdf_url}")
+    print(
+        "Wrote feeds: ekac-lap.ics, ekac-shallow.ics, ekac-dive.ics, ekac.ics "
+        f"from {debug.get('pdf')}"
+    )
     return 0
 
 

--- a/app/build_calendar.py
+++ b/app/build_calendar.py
@@ -327,7 +327,7 @@ def parse_pdf(url: str) -> tuple[list[Block], dict]:
             for offset, day in enumerate(DAYS):
                 local_date = week_start + timedelta(days=offset)
                 day_words = columns.get(day, [])
-                rows = [" ".join(w["text"] for w in _rows_from_words(day_words))]
+                rows = [" ".join(w["text"] for w in row) for row in _rows_from_words(day_words)]
                 page_dbg["days"][day] = {"rows": rows, "matches": []}
 
                 for blk in extract_blocks_for_day(day_words, local_date):


### PR DESCRIPTION
This PR splits the EKAC schedule into three feeds and adds a simple landing page:

- ekac-lap.ics — Lap lanes with lane counts in event summary
- ekac-shallow.ics — Shallow pool open blocks
- ekac-dive.ics — Dive well open blocks
- ekac.ics — Combined “all pools” feed

Also generates public/index.html with subscribe links. Keeps existing DEBUG + left-biased column parsing.
No workflow changes required (Pages still publishes everything under /public).